### PR TITLE
Fix ESLint configuration TypeScript compatibility issues

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,42 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Development Commands
+
+- **Start development server**: `npm run dev`
+- **Build for production**: `npm run build` (includes type checking)
+- **Type check only**: `npm run type-check`
+- **Lint code**: `npm run lint`
+- **Format code**: `npm run format`
+- **Run unit tests**: `npm run test:unit`
+- **Run e2e tests**: `npm run test:e2e`
+
+## Architecture
+
+This is a Vue 3 + TypeScript web application for an RPN (Reverse Polish Notation) calculator.
+
+**Tech Stack:**
+- Vue 3 with Composition API
+- TypeScript
+- Vite (build tool)
+- Pinia (state management)
+- Vitest (unit testing)
+- Playwright (e2e testing)
+- ESLint + Prettier (code quality)
+
+**Project Structure:**
+- `src/components/` - Vue components
+- `src/stores/` - Pinia stores for state management
+- `src/assets/` - Static assets (CSS, images)
+- `e2e/` - End-to-end tests
+- `src/components/__tests__/` - Unit tests
+
+**Key Conventions:**
+- Uses `@` alias for `src/` directory
+- Vue SFC (Single File Components) with `<script setup>` syntax
+- Composition API with Pinia stores
+- TypeScript strict mode enabled
+
+**Deployment Configuration:**
+- Vite base path is set to `/rpncalc-webapp/` for GitHub Pages deployment

--- a/eslint.config.ts
+++ b/eslint.config.ts
@@ -1,25 +1,50 @@
-import { globalIgnores } from 'eslint/config'
-import { defineConfigWithVueTs, vueTsConfigs } from '@vue/eslint-config-typescript'
 import pluginVue from 'eslint-plugin-vue'
 import pluginVitest from '@vitest/eslint-plugin'
 import pluginPlaywright from 'eslint-plugin-playwright'
 import skipFormatting from '@vue/eslint-config-prettier/skip-formatting'
+import tseslint from '@typescript-eslint/eslint-plugin'
+import tsParser from '@typescript-eslint/parser'
 
-// To allow more languages other than `ts` in `.vue` files, uncomment the following lines:
-// import { configureVueProject } from '@vue/eslint-config-typescript'
-// configureVueProject({ scriptLangs: ['ts', 'tsx'] })
-// More info at https://github.com/vuejs/eslint-config-typescript/#advanced-setup
-
-export default defineConfigWithVueTs(
+export default [
   {
-    name: 'app/files-to-lint',
-    files: ['**/*.{ts,mts,tsx,vue}'],
+    ignores: ['**/dist/**', '**/dist-ssr/**', '**/coverage/**'],
+  },
+  
+  ...pluginVue.configs['flat/essential'],
+  
+  {
+    files: ['**/*.{ts,mts,tsx}'],
+    languageOptions: {
+      parser: tsParser,
+      parserOptions: {
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tseslint,
+    },
+    rules: {
+      ...tseslint.configs.recommended.rules,
+    },
   },
 
-  globalIgnores(['**/dist/**', '**/dist-ssr/**', '**/coverage/**']),
-
-  pluginVue.configs['flat/essential'],
-  vueTsConfigs.recommended,
+  {
+    files: ['**/*.vue'],
+    languageOptions: {
+      parserOptions: {
+        parser: tsParser,
+        ecmaVersion: 'latest',
+        sourceType: 'module',
+      },
+    },
+    plugins: {
+      '@typescript-eslint': tseslint,
+    },
+    rules: {
+      ...tseslint.configs.recommended.rules,
+    },
+  },
   
   {
     ...pluginVitest.configs.recommended,
@@ -30,5 +55,6 @@ export default defineConfigWithVueTs(
     ...pluginPlaywright.configs['flat/recommended'],
     files: ['e2e/**/*.{test,spec}.{js,ts,jsx,tsx}'],
   },
+  
   skipFormatting,
-)
+]


### PR DESCRIPTION
## Summary
- Fixed TypeScript build errors caused by incompatible ESLint configuration
- Replaced `globalIgnores` import with standard flat config format
- Restructured ESLint config to properly handle both TypeScript and Vue files
- Added CLAUDE.md for development guidance

## Test plan
- [x] Build passes successfully (`npm run build`)
- [x] Linting works for both TypeScript and Vue files (`npm run lint`)
- [x] No TypeScript compilation errors

🤖 Generated with [Claude Code](https://claude.ai/code)