### PR TITLE
二進数・八進数・十進数・十六進数表示モード機能を実装

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -45,6 +45,11 @@ This is a Vue 3 + TypeScript web application for an RPN (Reverse Polish Notation
 
 - Vite base path is set to `/rpncalc-webapp/` for GitHub Pages deployment
 
+**Project rules**
+
+- コミット前にフォーマッタをかける。
+- コミット前にLintをかける
+
 **Output:**
 
 - 出力は全て日本語

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,10 +29,11 @@ This is a Vue 3 + TypeScript web application for an RPN (Reverse Polish Notation
 **Project Structure:**
 
 - `src/components/` - Vue components
+- `src/components/__tests__/` - Vue components Unit tests
 - `src/stores/` - Pinia stores for state management
+- `src/stores/__tests__/` - Unit tests of Pinia stores for state management
 - `src/assets/` - Static assets (CSS, images)
 - `e2e/` - End-to-end tests
-- `src/components/__tests__/` - Unit tests
 
 **Key Conventions:**
 

--- a/e2e/number-base-display.spec.ts
+++ b/e2e/number-base-display.spec.ts
@@ -1,0 +1,230 @@
+import { test, expect } from '@playwright/test'
+
+test.describe('RPN Calculator - Number Base Display', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.goto('/')
+  })
+
+  test('初期状態ではDECキーがアクティブである', async ({ page }) => {
+    // DECボタンがアクティブ状態で表示されることを確認
+    const decButton = page.getByRole('button', { name: 'DEC' })
+    await expect(decButton).toHaveClass(/active/)
+    
+    // 他のボタンはアクティブでないことを確認
+    await expect(page.getByRole('button', { name: 'BIN' })).not.toHaveClass(/active/)
+    await expect(page.getByRole('button', { name: 'OCT' })).not.toHaveClass(/active/)
+    await expect(page.getByRole('button', { name: 'HEX' })).not.toHaveClass(/active/)
+  })
+
+  test('BINキーを押すと二進数表示に切り替わる', async ({ page }) => {
+    // 数値をスタックに入力: 15
+    await page.getByRole('button', { name: '1' }).click()
+    await page.getByRole('button', { name: '5' }).click()
+    await page.getByRole('button', { name: 'Enter' }).click()
+
+    // BINキーをクリック
+    await page.getByRole('button', { name: 'BIN' }).click()
+
+    // BINボタンがアクティブになることを確認
+    await expect(page.getByRole('button', { name: 'BIN' })).toHaveClass(/active/)
+    await expect(page.getByRole('button', { name: 'DEC' })).not.toHaveClass(/active/)
+
+    // 15が二進数(0b1111)で表示されることを確認
+    await expect(page.locator('.stack-item').nth(3).locator('.stack-value')).toHaveText('0b1111')
+  })
+
+  test('OCTキーを押すと八進数表示に切り替わる', async ({ page }) => {
+    // 数値をスタックに入力: 64
+    await page.getByRole('button', { name: '6' }).click()
+    await page.getByRole('button', { name: '4' }).click()
+    await page.getByRole('button', { name: 'Enter' }).click()
+
+    // OCTキーをクリック
+    await page.getByRole('button', { name: 'OCT' }).click()
+
+    // OCTボタンがアクティブになることを確認
+    await expect(page.getByRole('button', { name: 'OCT' })).toHaveClass(/active/)
+    await expect(page.getByRole('button', { name: 'DEC' })).not.toHaveClass(/active/)
+
+    // 64が八進数(0o100)で表示されることを確認
+    await expect(page.locator('.stack-item').nth(3).locator('.stack-value')).toHaveText('0o100')
+  })
+
+  test('DECキーを押すと十進数表示に切り替わる', async ({ page }) => {
+    // まず二進数表示にする
+    await page.getByRole('button', { name: 'BIN' }).click()
+    
+    // 数値をスタックに入力: 42
+    await page.getByRole('button', { name: '4' }).click()
+    await page.getByRole('button', { name: '2' }).click()
+    await page.getByRole('button', { name: 'Enter' }).click()
+
+    // DECキーをクリック
+    await page.getByRole('button', { name: 'DEC' }).click()
+
+    // DECボタンがアクティブになることを確認
+    await expect(page.getByRole('button', { name: 'DEC' })).toHaveClass(/active/)
+    await expect(page.getByRole('button', { name: 'BIN' })).not.toHaveClass(/active/)
+
+    // 42が十進数で表示されることを確認
+    await expect(page.locator('.stack-item').nth(3).locator('.stack-value')).toHaveText('42')
+  })
+
+  test('HEXキーを押すと十六進数表示に切り替わる', async ({ page }) => {
+    // 数値をスタックに入力: 255
+    await page.getByRole('button', { name: '2' }).click()
+    await page.getByRole('button', { name: '5' }).click()
+    await page.getByRole('button', { name: '5' }).click()
+    await page.getByRole('button', { name: 'Enter' }).click()
+
+    // HEXキーをクリック
+    await page.getByRole('button', { name: 'HEX' }).click()
+
+    // HEXボタンがアクティブになることを確認
+    await expect(page.getByRole('button', { name: 'HEX' })).toHaveClass(/active/)
+    await expect(page.getByRole('button', { name: 'DEC' })).not.toHaveClass(/active/)
+
+    // 255が十六進数(0xFF)で表示されることを確認
+    await expect(page.locator('.stack-item').nth(3).locator('.stack-value')).toHaveText('0xFF')
+  })
+
+  test('複数の数値に対して表示モードが正しく適用される', async ({ page }) => {
+    // 複数の数値をスタックに積む: 8, 16, 32
+    await page.getByRole('button', { name: '8' }).click()
+    await page.getByRole('button', { name: 'Enter' }).click()
+    await page.getByRole('button', { name: '1' }).click()
+    await page.getByRole('button', { name: '6' }).click()
+    await page.getByRole('button', { name: 'Enter' }).click()
+    await page.getByRole('button', { name: '3' }).click()
+    await page.getByRole('button', { name: '2' }).click()
+    await page.getByRole('button', { name: 'Enter' }).click()
+
+    // 二進数表示に切り替え
+    await page.getByRole('button', { name: 'BIN' }).click()
+
+    // すべての値が二進数で表示されることを確認
+    await expect(page.locator('.stack-item').nth(1).locator('.stack-value')).toHaveText('0b1000')  // 8
+    await expect(page.locator('.stack-item').nth(2).locator('.stack-value')).toHaveText('0b10000') // 16
+    await expect(page.locator('.stack-item').nth(3).locator('.stack-value')).toHaveText('0b100000') // 32
+  })
+
+  test('十六進数表示で大文字が正しく表示される', async ({ page }) => {
+    // 数値をスタックに入力: 2748 (0xABC)
+    await page.getByRole('button', { name: '2' }).click()
+    await page.getByRole('button', { name: '7' }).click()
+    await page.getByRole('button', { name: '4' }).click()
+    await page.getByRole('button', { name: '8' }).click()
+    await page.getByRole('button', { name: 'Enter' }).click()
+
+    // HEXキーをクリック
+    await page.getByRole('button', { name: 'HEX' }).click()
+
+    // 十六進数で大文字のA, B, Cが正しく表示されることを確認
+    await expect(page.locator('.stack-item').nth(3).locator('.stack-value')).toHaveText('0xABC')
+  })
+
+  test('負の数値の表示モード切り替えが正しく動作する', async ({ page }) => {
+    // 負の数値をスタックに入力: -8
+    await page.getByRole('button', { name: '8' }).click()
+    await page.getByRole('button', { name: '+/-' }).click()
+    await page.getByRole('button', { name: 'Enter' }).click()
+
+    // 十進数表示での確認
+    await expect(page.locator('.stack-item').nth(3).locator('.stack-value')).toHaveText('-8')
+
+    // 二進数表示に切り替え
+    await page.getByRole('button', { name: 'BIN' }).click()
+
+    // 負の数値が正しく二進数表示されることを確認 (2の補数表現)
+    const stackValue = page.locator('.stack-item').nth(3).locator('.stack-value')
+    await expect(stackValue).toHaveText('0b11111111111111111111111111111000')
+  })
+
+  test('ゼロの表示モード切り替えが正しく動作する', async ({ page }) => {
+    // ゼロをスタックに入力
+    await page.getByRole('button', { name: '0' }).click()
+    await page.getByRole('button', { name: 'Enter' }).click()
+
+    // 各表示モードでゼロが正しく表示されることを確認
+    await page.getByRole('button', { name: 'BIN' }).click()
+    await expect(page.locator('.stack-item').nth(3).locator('.stack-value')).toHaveText('0b0')
+
+    await page.getByRole('button', { name: 'OCT' }).click()
+    await expect(page.locator('.stack-item').nth(3).locator('.stack-value')).toHaveText('0o0')
+
+    await page.getByRole('button', { name: 'HEX' }).click()
+    await expect(page.locator('.stack-item').nth(3).locator('.stack-value')).toHaveText('0x0')
+
+    await page.getByRole('button', { name: 'DEC' }).click()
+    await expect(page.locator('.stack-item').nth(3).locator('.stack-value')).toHaveText('0')
+  })
+
+  test('表示モード切り替え後も計算機能が正常に動作する', async ({ page }) => {
+    // 数値をスタックに積む: 12, 8
+    await page.getByRole('button', { name: '1' }).click()
+    await page.getByRole('button', { name: '2' }).click()
+    await page.getByRole('button', { name: 'Enter' }).click()
+    await page.getByRole('button', { name: '8' }).click()
+    await page.getByRole('button', { name: 'Enter' }).click()
+
+    // 二進数表示に切り替え
+    await page.getByRole('button', { name: 'BIN' }).click()
+
+    // 加算実行: 12 + 8 = 20
+    await page.getByRole('button', { name: '+', exact: true }).click()
+
+    // 結果が二進数で表示されることを確認 (20 = 0b10100)
+    await expect(page.locator('.stack-item').nth(3).locator('.stack-value')).toHaveText('0b10100')
+
+    // 十進数表示に戻して確認
+    await page.getByRole('button', { name: 'DEC' }).click()
+    await expect(page.locator('.stack-item').nth(3).locator('.stack-value')).toHaveText('20')
+  })
+
+  test('小数を含む数値は整数部分のみが変換される', async ({ page }) => {
+    // 小数を含む数値をスタックに入力: 15.7
+    await page.getByRole('button', { name: '1' }).click()
+    await page.getByRole('button', { name: '5' }).click()
+    await page.getByRole('button', { name: '.' }).click()
+    await page.getByRole('button', { name: '7' }).click()
+    await page.getByRole('button', { name: 'Enter' }).click()
+
+    // 二進数表示に切り替え
+    await page.getByRole('button', { name: 'BIN' }).click()
+
+    // 整数部分(15)のみが二進数変換されることを確認
+    await expect(page.locator('.stack-item').nth(3).locator('.stack-value')).toHaveText('0b1111')
+
+    // 十進数表示に戻すと元の値が表示される
+    await page.getByRole('button', { name: 'DEC' }).click()
+    await expect(page.locator('.stack-item').nth(3).locator('.stack-value')).toHaveText('15.7')
+  })
+
+  test('表示モードボタンの連続クリックで切り替わる', async ({ page }) => {
+    // 数値をスタックに入力: 100
+    await page.getByRole('button', { name: '1' }).click()
+    await page.getByRole('button', { name: '0' }).click()
+    await page.getByRole('button', { name: '0' }).click()
+    await page.getByRole('button', { name: 'Enter' }).click()
+
+    // DEC → BIN → OCT → HEX → DEC の順で切り替え
+    await expect(page.getByRole('button', { name: 'DEC' })).toHaveClass(/active/)
+    await expect(page.locator('.stack-item').nth(3).locator('.stack-value')).toHaveText('100')
+
+    await page.getByRole('button', { name: 'BIN' }).click()
+    await expect(page.getByRole('button', { name: 'BIN' })).toHaveClass(/active/)
+    await expect(page.locator('.stack-item').nth(3).locator('.stack-value')).toHaveText('0b1100100')
+
+    await page.getByRole('button', { name: 'OCT' }).click()
+    await expect(page.getByRole('button', { name: 'OCT' })).toHaveClass(/active/)
+    await expect(page.locator('.stack-item').nth(3).locator('.stack-value')).toHaveText('0o144')
+
+    await page.getByRole('button', { name: 'HEX' }).click()
+    await expect(page.getByRole('button', { name: 'HEX' })).toHaveClass(/active/)
+    await expect(page.locator('.stack-item').nth(3).locator('.stack-value')).toHaveText('0x64')
+
+    await page.getByRole('button', { name: 'DEC' }).click()
+    await expect(page.getByRole('button', { name: 'DEC' })).toHaveClass(/active/)
+    await expect(page.locator('.stack-item').nth(3).locator('.stack-value')).toHaveText('100')
+  })
+})

--- a/src/components/CalculatorButton.vue
+++ b/src/components/CalculatorButton.vue
@@ -19,10 +19,12 @@ interface Props {
   type: ButtonType
   className?: string
   disabled?: boolean
+  active?: boolean
 }
 
 const props = withDefaults(defineProps<Props>(), {
   disabled: false,
+  active: false,
 })
 
 defineEmits<{
@@ -38,6 +40,7 @@ const buttonClasses = computed(() => [
   {
     'button-disabled': props.disabled,
     'button-pressed': isPressed.value,
+    'button-active': props.active,
   },
 ])
 
@@ -128,6 +131,11 @@ const onTouchEnd = () => {
 
 .button-disabled:hover {
   transform: none;
+}
+
+.button-active {
+  background-color: var(--sol-violet) !important;
+  color: var(--sol-base3) !important;
 }
 
 /* Special spacing for empty grid cell */

--- a/src/components/CalculatorButton.vue
+++ b/src/components/CalculatorButton.vue
@@ -1,7 +1,8 @@
 <template>
   <button
     :class="buttonClasses"
-    @click="$emit('click', value)"
+    :disabled="disabled"
+    @click="handleClick"
     @touchstart.passive="onTouchStart"
     @touchend.passive="onTouchEnd"
   >
@@ -27,7 +28,7 @@ const props = withDefaults(defineProps<Props>(), {
   active: false,
 })
 
-defineEmits<{
+const emit = defineEmits<{
   click: [value: string]
 }>()
 
@@ -52,6 +53,12 @@ const onTouchStart = () => {
 
 const onTouchEnd = () => {
   isPressed.value = false
+}
+
+const handleClick = () => {
+  if (!props.disabled) {
+    emit('click', props.value)
+  }
 }
 </script>
 

--- a/src/components/CalculatorDisplay.vue
+++ b/src/components/CalculatorDisplay.vue
@@ -4,10 +4,15 @@
     <div
       v-for="(item, index) in stackDisplay"
       :key="`stack-${index}`"
-      :class="['stack-item', { 'current-input': item.isCurrentInput }]"
+      :class="['stack-item', { 'current-input': item.isCurrentInput, 'binary-mode': displayMode === 'binary' }]"
     >
       <div class="stack-label">{{ item.label }}</div>
-      <div class="stack-value">{{ item.value }}</div>
+      <div 
+        class="stack-value" 
+        :class="{ 'binary-display': displayMode === 'binary' && item.value.startsWith('0b') }"
+      >
+        {{ item.value }}
+      </div>
     </div>
   </div>
 </template>
@@ -19,6 +24,8 @@ interface Props {
   stack: number[]
   currentInput: string
   inputMode: boolean
+  displayMode: 'decimal' | 'binary'
+  toBinaryString: (value: number) => string
 }
 
 const props = defineProps<Props>()
@@ -56,6 +63,12 @@ const stackDisplay = computed(() => {
 })
 
 const formatNumber = (value: number): string => {
+  // Binary mode
+  if (props.displayMode === 'binary') {
+    return props.toBinaryString(value)
+  }
+
+  // Decimal mode - original logic
   // Handle special cases
   if (value === 0) return '0'
   if (!isFinite(value)) return 'Error'
@@ -115,6 +128,12 @@ const formatNumber = (value: number): string => {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
+}
+
+/* Binary mode styling for better readability */
+.stack-value.binary-display {
+  font-size: 1.6rem;
+  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
 }
 
 .stack-item.current-input .stack-value {

--- a/src/components/CalculatorDisplay.vue
+++ b/src/components/CalculatorDisplay.vue
@@ -6,13 +6,20 @@
       :key="`stack-${index}`"
       :class="[
         'stack-item',
-        { 'current-input': item.isCurrentInput, 'binary-mode': displayMode === 'binary' },
+        {
+          'current-input': item.isCurrentInput,
+          'binary-mode': displayMode === 'binary',
+          'octal-mode': displayMode === 'octal',
+        },
       ]"
     >
       <div class="stack-label">{{ item.label }}</div>
       <div
         class="stack-value"
-        :class="{ 'binary-display': displayMode === 'binary' && item.value.startsWith('0b') }"
+        :class="{
+          'binary-display': displayMode === 'binary' && item.value.startsWith('0b'),
+          'octal-display': displayMode === 'octal' && item.value.startsWith('0o'),
+        }"
       >
         {{ item.value }}
       </div>
@@ -27,8 +34,9 @@ interface Props {
   stack: number[]
   currentInput: string
   inputMode: boolean
-  displayMode: 'decimal' | 'binary'
+  displayMode: 'decimal' | 'binary' | 'octal'
   toBinaryString: (value: number) => string
+  toOctalString: (value: number) => string
 }
 
 const props = defineProps<Props>()
@@ -69,6 +77,11 @@ const formatNumber = (value: number): string => {
   // Binary mode
   if (props.displayMode === 'binary') {
     return props.toBinaryString(value)
+  }
+
+  // Octal mode
+  if (props.displayMode === 'octal') {
+    return props.toOctalString(value)
   }
 
   // Decimal mode - original logic
@@ -136,6 +149,12 @@ const formatNumber = (value: number): string => {
 /* Binary mode styling for better readability */
 .stack-value.binary-display {
   font-size: 1.6rem;
+  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
+}
+
+/* Octal mode styling for better readability */
+.stack-value.octal-display {
+  font-size: 1.7rem;
   font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
 }
 

--- a/src/components/CalculatorDisplay.vue
+++ b/src/components/CalculatorDisplay.vue
@@ -4,11 +4,14 @@
     <div
       v-for="(item, index) in stackDisplay"
       :key="`stack-${index}`"
-      :class="['stack-item', { 'current-input': item.isCurrentInput, 'binary-mode': displayMode === 'binary' }]"
+      :class="[
+        'stack-item',
+        { 'current-input': item.isCurrentInput, 'binary-mode': displayMode === 'binary' },
+      ]"
     >
       <div class="stack-label">{{ item.label }}</div>
-      <div 
-        class="stack-value" 
+      <div
+        class="stack-value"
         :class="{ 'binary-display': displayMode === 'binary' && item.value.startsWith('0b') }"
       >
         {{ item.value }}

--- a/src/components/CalculatorDisplay.vue
+++ b/src/components/CalculatorDisplay.vue
@@ -10,6 +10,7 @@
           'current-input': item.isCurrentInput,
           'binary-mode': displayMode === 'binary',
           'octal-mode': displayMode === 'octal',
+          'hex-mode': displayMode === 'hexadecimal',
         },
       ]"
     >
@@ -19,6 +20,7 @@
         :class="{
           'binary-display': displayMode === 'binary' && item.value.startsWith('0b'),
           'octal-display': displayMode === 'octal' && item.value.startsWith('0o'),
+          'hex-display': displayMode === 'hexadecimal' && item.value.startsWith('0x'),
         }"
       >
         {{ item.value }}
@@ -34,9 +36,10 @@ interface Props {
   stack: number[]
   currentInput: string
   inputMode: boolean
-  displayMode: 'decimal' | 'binary' | 'octal'
+  displayMode: 'decimal' | 'binary' | 'octal' | 'hexadecimal'
   toBinaryString: (value: number) => string
   toOctalString: (value: number) => string
+  toHexString: (value: number) => string
 }
 
 const props = defineProps<Props>()
@@ -82,6 +85,11 @@ const formatNumber = (value: number): string => {
   // Octal mode
   if (props.displayMode === 'octal') {
     return props.toOctalString(value)
+  }
+
+  // Hexadecimal mode
+  if (props.displayMode === 'hexadecimal') {
+    return props.toHexString(value)
   }
 
   // Decimal mode - original logic
@@ -155,6 +163,12 @@ const formatNumber = (value: number): string => {
 /* Octal mode styling for better readability */
 .stack-value.octal-display {
   font-size: 1.7rem;
+  font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
+}
+
+/* Hexadecimal mode styling for better readability */
+.stack-value.hex-display {
+  font-size: 1.6rem;
   font-family: 'SF Mono', 'Monaco', 'Inconsolata', 'Roboto Mono', monospace;
 }
 

--- a/src/components/CalculatorKeyboard.vue
+++ b/src/components/CalculatorKeyboard.vue
@@ -5,26 +5,18 @@
         label="BIN"
         value="bin"
         type="function"
+        :active="props.displayMode === 'binary'"
         @click="handleButtonClick"
       />
-      <CalculatorButton
-        label="OCT"
-        value="oct"
-        type="function"
-        @click="handleButtonClick"
-      />
+      <CalculatorButton label="OCT" value="oct" type="function" @click="handleButtonClick" />
       <CalculatorButton
         label="DEC"
         value="dec"
         type="function"
+        :active="props.displayMode === 'decimal'"
         @click="handleButtonClick"
       />
-      <CalculatorButton
-        label="HEX"
-        value="hex"
-        type="function"
-        @click="handleButtonClick"
-      />
+      <CalculatorButton label="HEX" value="hex" type="function" @click="handleButtonClick" />
     </div>
     <!-- Row 1: Enter (3.5 columns), +/-, EEX -->
     <div class="keyboard-row">
@@ -85,6 +77,14 @@
 
 <script setup lang="ts">
 import CalculatorButton from './CalculatorButton.vue'
+
+interface Props {
+  displayMode?: 'decimal' | 'binary'
+}
+
+const props = withDefaults(defineProps<Props>(), {
+  displayMode: 'decimal',
+})
 
 const emit = defineEmits<{
   buttonPress: [value: string]

--- a/src/components/CalculatorKeyboard.vue
+++ b/src/components/CalculatorKeyboard.vue
@@ -1,5 +1,31 @@
 <template>
   <div class="calculator-keyboard">
+    <div class="keyboard-row">
+      <CalculatorButton
+        label="BIN"
+        value="bin"
+        type="function"
+        @click="handleButtonClick"
+      />
+      <CalculatorButton
+        label="OCT"
+        value="oct"
+        type="function"
+        @click="handleButtonClick"
+      />
+      <CalculatorButton
+        label="DEC"
+        value="dec"
+        type="function"
+        @click="handleButtonClick"
+      />
+      <CalculatorButton
+        label="HEX"
+        value="hex"
+        type="function"
+        @click="handleButtonClick"
+      />
+    </div>
     <!-- Row 1: Enter (3.5 columns), +/-, EEX -->
     <div class="keyboard-row">
       <CalculatorButton
@@ -87,7 +113,7 @@ const handleButtonClick = (value: string) => {
   min-height: 60px;
 }
 
-/* Enter button spans exactly 3 columns including gaps */
+/* Enter button spans exactly 2 columns including gaps */
 .enter-button {
   grid-column: span 3;
 }

--- a/src/components/CalculatorKeyboard.vue
+++ b/src/components/CalculatorKeyboard.vue
@@ -22,7 +22,13 @@
         :active="props.displayMode === 'decimal'"
         @click="handleButtonClick"
       />
-      <CalculatorButton label="HEX" value="hex" type="function" @click="handleButtonClick" />
+      <CalculatorButton
+        label="HEX"
+        value="hex"
+        type="function"
+        :active="props.displayMode === 'hexadecimal'"
+        @click="handleButtonClick"
+      />
     </div>
     <!-- Row 1: Enter (3.5 columns), +/-, EEX -->
     <div class="keyboard-row">
@@ -85,7 +91,7 @@
 import CalculatorButton from './CalculatorButton.vue'
 
 interface Props {
-  displayMode?: 'decimal' | 'binary' | 'octal'
+  displayMode?: 'decimal' | 'binary' | 'octal' | 'hexadecimal'
 }
 
 const props = withDefaults(defineProps<Props>(), {

--- a/src/components/CalculatorKeyboard.vue
+++ b/src/components/CalculatorKeyboard.vue
@@ -8,7 +8,13 @@
         :active="props.displayMode === 'binary'"
         @click="handleButtonClick"
       />
-      <CalculatorButton label="OCT" value="oct" type="function" @click="handleButtonClick" />
+      <CalculatorButton
+        label="OCT"
+        value="oct"
+        type="function"
+        :active="props.displayMode === 'octal'"
+        @click="handleButtonClick"
+      />
       <CalculatorButton
         label="DEC"
         value="dec"
@@ -79,7 +85,7 @@
 import CalculatorButton from './CalculatorButton.vue'
 
 interface Props {
-  displayMode?: 'decimal' | 'binary'
+  displayMode?: 'decimal' | 'binary' | 'octal'
 }
 
 const props = withDefaults(defineProps<Props>(), {

--- a/src/components/RPNCalculator.vue
+++ b/src/components/RPNCalculator.vue
@@ -11,7 +11,7 @@
     </div>
 
     <div class="calculator-keyboard-area">
-      <CalculatorKeyboard @button-press="handleButtonPress" />
+      <CalculatorKeyboard :display-mode="store.displayMode" @button-press="handleButtonPress" />
     </div>
   </div>
 </template>

--- a/src/components/RPNCalculator.vue
+++ b/src/components/RPNCalculator.vue
@@ -8,6 +8,7 @@
         :display-mode="store.displayMode"
         :to-binary-string="store.toBinaryString"
         :to-octal-string="store.toOctalString"
+        :to-hex-string="store.toHexString"
       />
     </div>
 
@@ -97,8 +98,7 @@ const handleButtonPress = (value: string) => {
       break
 
     case 'hex':
-      // HEX mode not implemented yet
-      console.warn('Display mode not implemented:', value)
+      store.setDisplayMode('hexadecimal')
       break
 
     default:

--- a/src/components/RPNCalculator.vue
+++ b/src/components/RPNCalculator.vue
@@ -7,6 +7,7 @@
         :input-mode="store.inputMode"
         :display-mode="store.displayMode"
         :to-binary-string="store.toBinaryString"
+        :to-octal-string="store.toOctalString"
       />
     </div>
 
@@ -92,8 +93,11 @@ const handleButtonPress = (value: string) => {
       break
 
     case 'oct':
+      store.setDisplayMode('octal')
+      break
+
     case 'hex':
-      // OCT and HEX modes not implemented yet
+      // HEX mode not implemented yet
       console.warn('Display mode not implemented:', value)
       break
 

--- a/src/components/RPNCalculator.vue
+++ b/src/components/RPNCalculator.vue
@@ -5,6 +5,8 @@
         :stack="store.stack"
         :current-input="store.currentDisplay"
         :input-mode="store.inputMode"
+        :display-mode="store.displayMode"
+        :to-binary-string="store.toBinaryString"
       />
     </div>
 
@@ -79,6 +81,20 @@ const handleButtonPress = (value: string) => {
 
     case 'undo':
       store.undoLastOperation()
+      break
+
+    case 'bin':
+      store.setDisplayMode('binary')
+      break
+
+    case 'dec':
+      store.setDisplayMode('decimal')
+      break
+
+    case 'oct':
+    case 'hex':
+      // OCT and HEX modes not implemented yet
+      console.warn('Display mode not implemented:', value)
       break
 
     default:

--- a/src/components/__tests__/CalculatorButton.test.ts
+++ b/src/components/__tests__/CalculatorButton.test.ts
@@ -1,0 +1,201 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import CalculatorButton from '../CalculatorButton.vue'
+
+describe('CalculatorButton', () => {
+  describe('Active State', () => {
+    it('should apply button-active class when active prop is true', () => {
+      const wrapper = mount(CalculatorButton, {
+        props: {
+          label: 'BIN',
+          value: 'bin',
+          type: 'function',
+          active: true,
+        },
+      })
+
+      expect(wrapper.classes()).toContain('button-active')
+    })
+
+    it('should not apply button-active class when active prop is false', () => {
+      const wrapper = mount(CalculatorButton, {
+        props: {
+          label: 'BIN',
+          value: 'bin',
+          type: 'function',
+          active: false,
+        },
+      })
+
+      expect(wrapper.classes()).not.toContain('button-active')
+    })
+
+    it('should not apply button-active class when active prop is not provided', () => {
+      const wrapper = mount(CalculatorButton, {
+        props: {
+          label: 'BIN',
+          value: 'bin',
+          type: 'function',
+        },
+      })
+
+      expect(wrapper.classes()).not.toContain('button-active')
+    })
+
+    it('should apply both active and pressed classes when both conditions are met', async () => {
+      const wrapper = mount(CalculatorButton, {
+        props: {
+          label: 'BIN',
+          value: 'bin',
+          type: 'function',
+          active: true,
+        },
+      })
+
+      // Simulate touch start to trigger pressed state
+      await wrapper.trigger('touchstart')
+      
+      expect(wrapper.classes()).toContain('button-active')
+      expect(wrapper.classes()).toContain('button-pressed')
+    })
+  })
+
+  describe('Basic Functionality', () => {
+    it('should render the correct label', () => {
+      const wrapper = mount(CalculatorButton, {
+        props: {
+          label: 'Test Label',
+          value: 'test',
+          type: 'function',
+        },
+      })
+
+      expect(wrapper.text()).toBe('Test Label')
+    })
+
+    it('should emit click event with correct value when clicked', async () => {
+      const wrapper = mount(CalculatorButton, {
+        props: {
+          label: 'BIN',
+          value: 'bin',
+          type: 'function',
+        },
+      })
+
+      await wrapper.trigger('click')
+
+      expect(wrapper.emitted('click')).toBeTruthy()
+      expect(wrapper.emitted('click')![0]).toEqual(['bin'])
+    })
+
+    it('should apply disabled class when disabled prop is true', () => {
+      const wrapper = mount(CalculatorButton, {
+        props: {
+          label: 'BIN',
+          value: 'bin',
+          type: 'function',
+          disabled: true,
+        },
+      })
+
+      expect(wrapper.classes()).toContain('button-disabled')
+    })
+
+    it('should apply correct type class', () => {
+      const wrapper = mount(CalculatorButton, {
+        props: {
+          label: 'BIN',
+          value: 'bin',
+          type: 'function',
+        },
+      })
+
+      expect(wrapper.classes()).toContain('button-function')
+    })
+  })
+
+  describe('Active State with Different Button Types', () => {
+    it('should apply active state to number buttons', () => {
+      const wrapper = mount(CalculatorButton, {
+        props: {
+          label: '1',
+          value: '1',
+          type: 'number',
+          active: true,
+        },
+      })
+
+      expect(wrapper.classes()).toContain('button-active')
+      expect(wrapper.classes()).toContain('button-number')
+    })
+
+    it('should apply active state to operator buttons', () => {
+      const wrapper = mount(CalculatorButton, {
+        props: {
+          label: '+',
+          value: '+',
+          type: 'operator',
+          active: true,
+        },
+      })
+
+      expect(wrapper.classes()).toContain('button-active')
+      expect(wrapper.classes()).toContain('button-operator')
+    })
+
+    it('should apply active state to enter buttons', () => {
+      const wrapper = mount(CalculatorButton, {
+        props: {
+          label: 'Enter',
+          value: 'enter',
+          type: 'enter',
+          active: true,
+        },
+      })
+
+      expect(wrapper.classes()).toContain('button-active')
+      expect(wrapper.classes()).toContain('button-enter')
+    })
+  })
+
+  describe('Interaction States', () => {
+    it('should handle touch interactions correctly with active state', async () => {
+      const wrapper = mount(CalculatorButton, {
+        props: {
+          label: 'BIN',
+          value: 'bin',
+          type: 'function',
+          active: true,
+        },
+      })
+
+      // Touch start should add pressed class while keeping active class
+      await wrapper.trigger('touchstart')
+      expect(wrapper.classes()).toContain('button-active')
+      expect(wrapper.classes()).toContain('button-pressed')
+
+      // Touch end should remove pressed class but keep active class
+      await wrapper.trigger('touchend')
+      expect(wrapper.classes()).toContain('button-active')
+      expect(wrapper.classes()).not.toContain('button-pressed')
+    })
+
+    it('should not emit click event when disabled even if active', async () => {
+      const wrapper = mount(CalculatorButton, {
+        props: {
+          label: 'BIN',
+          value: 'bin',
+          type: 'function',
+          active: true,
+          disabled: true,
+        },
+      })
+
+      await wrapper.trigger('click')
+
+      expect(wrapper.emitted('click')).toBeFalsy()
+      expect(wrapper.classes()).toContain('button-active')
+      expect(wrapper.classes()).toContain('button-disabled')
+    })
+  })
+})

--- a/src/components/__tests__/CalculatorButton.test.ts
+++ b/src/components/__tests__/CalculatorButton.test.ts
@@ -54,7 +54,7 @@ describe('CalculatorButton', () => {
 
       // Simulate touch start to trigger pressed state
       await wrapper.trigger('touchstart')
-      
+
       expect(wrapper.classes()).toContain('button-active')
       expect(wrapper.classes()).toContain('button-pressed')
     })

--- a/src/components/__tests__/CalculatorKeyboard.test.ts
+++ b/src/components/__tests__/CalculatorKeyboard.test.ts
@@ -13,8 +13,8 @@ describe('CalculatorKeyboard', () => {
       })
 
       const buttons = wrapper.findAllComponents(CalculatorButton)
-      const binButton = buttons.find(button => button.props('value') === 'bin')
-      const decButton = buttons.find(button => button.props('value') === 'dec')
+      const binButton = buttons.find((button) => button.props('value') === 'bin')
+      const decButton = buttons.find((button) => button.props('value') === 'dec')
 
       expect(binButton?.props('active')).toBe(true)
       expect(decButton?.props('active')).toBe(false)
@@ -28,8 +28,8 @@ describe('CalculatorKeyboard', () => {
       })
 
       const buttons = wrapper.findAllComponents(CalculatorButton)
-      const binButton = buttons.find(button => button.props('value') === 'bin')
-      const decButton = buttons.find(button => button.props('value') === 'dec')
+      const binButton = buttons.find((button) => button.props('value') === 'bin')
+      const decButton = buttons.find((button) => button.props('value') === 'dec')
 
       expect(binButton?.props('active')).toBe(false)
       expect(decButton?.props('active')).toBe(true)
@@ -39,14 +39,31 @@ describe('CalculatorKeyboard', () => {
       const wrapper = mount(CalculatorKeyboard)
 
       const buttons = wrapper.findAllComponents(CalculatorButton)
-      const binButton = buttons.find(button => button.props('value') === 'bin')
-      const decButton = buttons.find(button => button.props('value') === 'dec')
+      const binButton = buttons.find((button) => button.props('value') === 'bin')
+      const decButton = buttons.find((button) => button.props('value') === 'dec')
 
       expect(binButton?.props('active')).toBe(false)
       expect(decButton?.props('active')).toBe(true)
     })
 
-    it('should not activate OCT or HEX buttons regardless of display mode', () => {
+    it('should activate OCT button when display mode is octal', () => {
+      const wrapper = mount(CalculatorKeyboard, {
+        props: {
+          displayMode: 'octal',
+        },
+      })
+
+      const buttons = wrapper.findAllComponents(CalculatorButton)
+      const binButton = buttons.find((button) => button.props('value') === 'bin')
+      const octButton = buttons.find((button) => button.props('value') === 'oct')
+      const decButton = buttons.find((button) => button.props('value') === 'dec')
+
+      expect(binButton?.props('active')).toBe(false)
+      expect(octButton?.props('active')).toBe(true)
+      expect(decButton?.props('active')).toBe(false)
+    })
+
+    it('should not activate HEX button regardless of display mode', () => {
       const wrapper = mount(CalculatorKeyboard, {
         props: {
           displayMode: 'binary',
@@ -54,10 +71,8 @@ describe('CalculatorKeyboard', () => {
       })
 
       const buttons = wrapper.findAllComponents(CalculatorButton)
-      const octButton = buttons.find(button => button.props('value') === 'oct')
-      const hexButton = buttons.find(button => button.props('value') === 'hex')
+      const hexButton = buttons.find((button) => button.props('value') === 'hex')
 
-      expect(octButton?.props('active')).toBe(false)
       expect(hexButton?.props('active')).toBe(false)
     })
   })
@@ -72,9 +87,9 @@ describe('CalculatorKeyboard', () => {
 
       // Initially DEC should be active
       let buttons = wrapper.findAllComponents(CalculatorButton)
-      let binButton = buttons.find(button => button.props('value') === 'bin')
-      let decButton = buttons.find(button => button.props('value') === 'dec')
-      
+      let binButton = buttons.find((button) => button.props('value') === 'bin')
+      let decButton = buttons.find((button) => button.props('value') === 'dec')
+
       expect(binButton?.props('active')).toBe(false)
       expect(decButton?.props('active')).toBe(true)
 
@@ -83,8 +98,8 @@ describe('CalculatorKeyboard', () => {
 
       // Now BIN should be active
       buttons = wrapper.findAllComponents(CalculatorButton)
-      binButton = buttons.find(button => button.props('value') === 'bin')
-      decButton = buttons.find(button => button.props('value') === 'dec')
+      binButton = buttons.find((button) => button.props('value') === 'bin')
+      decButton = buttons.find((button) => button.props('value') === 'dec')
 
       expect(binButton?.props('active')).toBe(true)
       expect(decButton?.props('active')).toBe(false)
@@ -99,9 +114,9 @@ describe('CalculatorKeyboard', () => {
 
       // Initially BIN should be active
       let buttons = wrapper.findAllComponents(CalculatorButton)
-      let binButton = buttons.find(button => button.props('value') === 'bin')
-      let decButton = buttons.find(button => button.props('value') === 'dec')
-      
+      let binButton = buttons.find((button) => button.props('value') === 'bin')
+      let decButton = buttons.find((button) => button.props('value') === 'dec')
+
       expect(binButton?.props('active')).toBe(true)
       expect(decButton?.props('active')).toBe(false)
 
@@ -110,10 +125,64 @@ describe('CalculatorKeyboard', () => {
 
       // Now DEC should be active
       buttons = wrapper.findAllComponents(CalculatorButton)
-      binButton = buttons.find(button => button.props('value') === 'bin')
-      decButton = buttons.find(button => button.props('value') === 'dec')
+      binButton = buttons.find((button) => button.props('value') === 'bin')
+      decButton = buttons.find((button) => button.props('value') === 'dec')
 
       expect(binButton?.props('active')).toBe(false)
+      expect(decButton?.props('active')).toBe(true)
+    })
+
+    it('should update active states when display mode changes from decimal to octal', async () => {
+      const wrapper = mount(CalculatorKeyboard, {
+        props: {
+          displayMode: 'decimal',
+        },
+      })
+
+      // Initially DEC should be active
+      let buttons = wrapper.findAllComponents(CalculatorButton)
+      let octButton = buttons.find((button) => button.props('value') === 'oct')
+      let decButton = buttons.find((button) => button.props('value') === 'dec')
+
+      expect(octButton?.props('active')).toBe(false)
+      expect(decButton?.props('active')).toBe(true)
+
+      // Change to octal mode
+      await wrapper.setProps({ displayMode: 'octal' })
+
+      // Now OCT should be active
+      buttons = wrapper.findAllComponents(CalculatorButton)
+      octButton = buttons.find((button) => button.props('value') === 'oct')
+      decButton = buttons.find((button) => button.props('value') === 'dec')
+
+      expect(octButton?.props('active')).toBe(true)
+      expect(decButton?.props('active')).toBe(false)
+    })
+
+    it('should update active states when display mode changes from octal to decimal', async () => {
+      const wrapper = mount(CalculatorKeyboard, {
+        props: {
+          displayMode: 'octal',
+        },
+      })
+
+      // Initially OCT should be active
+      let buttons = wrapper.findAllComponents(CalculatorButton)
+      let octButton = buttons.find((button) => button.props('value') === 'oct')
+      let decButton = buttons.find((button) => button.props('value') === 'dec')
+
+      expect(octButton?.props('active')).toBe(true)
+      expect(decButton?.props('active')).toBe(false)
+
+      // Change to decimal mode
+      await wrapper.setProps({ displayMode: 'decimal' })
+
+      // Now DEC should be active
+      buttons = wrapper.findAllComponents(CalculatorButton)
+      octButton = buttons.find((button) => button.props('value') === 'oct')
+      decButton = buttons.find((button) => button.props('value') === 'dec')
+
+      expect(octButton?.props('active')).toBe(false)
       expect(decButton?.props('active')).toBe(true)
     })
   })
@@ -127,7 +196,7 @@ describe('CalculatorKeyboard', () => {
       })
 
       const buttons = wrapper.findAllComponents(CalculatorButton)
-      const binButton = buttons.find(button => button.props('value') === 'bin')
+      const binButton = buttons.find((button) => button.props('value') === 'bin')
 
       await binButton?.trigger('click')
 
@@ -143,7 +212,7 @@ describe('CalculatorKeyboard', () => {
       })
 
       const buttons = wrapper.findAllComponents(CalculatorButton)
-      const decButton = buttons.find(button => button.props('value') === 'dec')
+      const decButton = buttons.find((button) => button.props('value') === 'dec')
 
       await decButton?.trigger('click')
 
@@ -155,7 +224,7 @@ describe('CalculatorKeyboard', () => {
       const wrapper = mount(CalculatorKeyboard)
 
       const buttons = wrapper.findAllComponents(CalculatorButton)
-      
+
       // Test a few different button types
       const testButtons = [
         { value: 'bin', label: 'BIN' },
@@ -165,7 +234,7 @@ describe('CalculatorKeyboard', () => {
       ]
 
       for (const testButton of testButtons) {
-        const button = buttons.find(b => b.props('value') === testButton.value)
+        const button = buttons.find((b) => b.props('value') === testButton.value)
         if (button) {
           await button.trigger('click')
           expect(wrapper.emitted('buttonPress')).toBeTruthy()
@@ -182,7 +251,7 @@ describe('CalculatorKeyboard', () => {
       const displayModeButtons = ['bin', 'oct', 'dec', 'hex']
 
       for (const buttonValue of displayModeButtons) {
-        const button = buttons.find(b => b.props('value') === buttonValue)
+        const button = buttons.find((b) => b.props('value') === buttonValue)
         expect(button).toBeTruthy()
       }
     })
@@ -194,7 +263,7 @@ describe('CalculatorKeyboard', () => {
       const numericButtons = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
 
       for (const buttonValue of numericButtons) {
-        const button = buttons.find(b => b.props('value') === buttonValue)
+        const button = buttons.find((b) => b.props('value') === buttonValue)
         expect(button).toBeTruthy()
       }
     })
@@ -206,7 +275,7 @@ describe('CalculatorKeyboard', () => {
       const operatorButtons = ['+', '-', '×', '÷']
 
       for (const buttonValue of operatorButtons) {
-        const button = buttons.find(b => b.props('value') === buttonValue)
+        const button = buttons.find((b) => b.props('value') === buttonValue)
         expect(button).toBeTruthy()
       }
     })
@@ -218,7 +287,7 @@ describe('CalculatorKeyboard', () => {
       const functionButtons = ['enter', 'toggle-sign', 'eex', 'delete', 'undo', 'swap', 'drop']
 
       for (const buttonValue of functionButtons) {
-        const button = buttons.find(b => b.props('value') === buttonValue)
+        const button = buttons.find((b) => b.props('value') === buttonValue)
         expect(button).toBeTruthy()
       }
     })
@@ -233,7 +302,7 @@ describe('CalculatorKeyboard', () => {
       })
 
       const buttons = wrapper.findAllComponents(CalculatorButton)
-      const binButton = buttons.find(button => button.props('value') === 'bin')
+      const binButton = buttons.find((button) => button.props('value') === 'bin')
 
       expect(binButton?.props('active')).toBe(true)
       expect(binButton?.classes()).toContain('button-active')
@@ -247,7 +316,7 @@ describe('CalculatorKeyboard', () => {
       })
 
       const buttons = wrapper.findAllComponents(CalculatorButton)
-      const decButton = buttons.find(button => button.props('value') === 'dec')
+      const decButton = buttons.find((button) => button.props('value') === 'dec')
 
       expect(decButton?.props('active')).toBe(true)
       expect(decButton?.classes()).toContain('button-active')
@@ -260,7 +329,7 @@ describe('CalculatorKeyboard', () => {
       const displayModeButtons = ['bin', 'oct', 'dec', 'hex']
 
       for (const buttonValue of displayModeButtons) {
-        const button = buttons.find(b => b.props('value') === buttonValue)
+        const button = buttons.find((b) => b.props('value') === buttonValue)
         expect(button?.props('type')).toBe('function')
       }
     })

--- a/src/components/__tests__/CalculatorKeyboard.test.ts
+++ b/src/components/__tests__/CalculatorKeyboard.test.ts
@@ -63,17 +63,23 @@ describe('CalculatorKeyboard', () => {
       expect(decButton?.props('active')).toBe(false)
     })
 
-    it('should not activate HEX button regardless of display mode', () => {
+    it('should activate HEX button when display mode is hexadecimal', () => {
       const wrapper = mount(CalculatorKeyboard, {
         props: {
-          displayMode: 'binary',
+          displayMode: 'hexadecimal',
         },
       })
 
       const buttons = wrapper.findAllComponents(CalculatorButton)
+      const binButton = buttons.find((button) => button.props('value') === 'bin')
+      const octButton = buttons.find((button) => button.props('value') === 'oct')
+      const decButton = buttons.find((button) => button.props('value') === 'dec')
       const hexButton = buttons.find((button) => button.props('value') === 'hex')
 
-      expect(hexButton?.props('active')).toBe(false)
+      expect(binButton?.props('active')).toBe(false)
+      expect(octButton?.props('active')).toBe(false)
+      expect(decButton?.props('active')).toBe(false)
+      expect(hexButton?.props('active')).toBe(true)
     })
   })
 
@@ -183,6 +189,60 @@ describe('CalculatorKeyboard', () => {
       decButton = buttons.find((button) => button.props('value') === 'dec')
 
       expect(octButton?.props('active')).toBe(false)
+      expect(decButton?.props('active')).toBe(true)
+    })
+
+    it('should update active states when display mode changes from decimal to hexadecimal', async () => {
+      const wrapper = mount(CalculatorKeyboard, {
+        props: {
+          displayMode: 'decimal',
+        },
+      })
+
+      // Initially DEC should be active
+      let buttons = wrapper.findAllComponents(CalculatorButton)
+      let hexButton = buttons.find((button) => button.props('value') === 'hex')
+      let decButton = buttons.find((button) => button.props('value') === 'dec')
+
+      expect(hexButton?.props('active')).toBe(false)
+      expect(decButton?.props('active')).toBe(true)
+
+      // Change to hexadecimal mode
+      await wrapper.setProps({ displayMode: 'hexadecimal' })
+
+      // Now HEX should be active
+      buttons = wrapper.findAllComponents(CalculatorButton)
+      hexButton = buttons.find((button) => button.props('value') === 'hex')
+      decButton = buttons.find((button) => button.props('value') === 'dec')
+
+      expect(hexButton?.props('active')).toBe(true)
+      expect(decButton?.props('active')).toBe(false)
+    })
+
+    it('should update active states when display mode changes from hexadecimal to decimal', async () => {
+      const wrapper = mount(CalculatorKeyboard, {
+        props: {
+          displayMode: 'hexadecimal',
+        },
+      })
+
+      // Initially HEX should be active
+      let buttons = wrapper.findAllComponents(CalculatorButton)
+      let hexButton = buttons.find((button) => button.props('value') === 'hex')
+      let decButton = buttons.find((button) => button.props('value') === 'dec')
+
+      expect(hexButton?.props('active')).toBe(true)
+      expect(decButton?.props('active')).toBe(false)
+
+      // Change to decimal mode
+      await wrapper.setProps({ displayMode: 'decimal' })
+
+      // Now DEC should be active
+      buttons = wrapper.findAllComponents(CalculatorButton)
+      hexButton = buttons.find((button) => button.props('value') === 'hex')
+      decButton = buttons.find((button) => button.props('value') === 'dec')
+
+      expect(hexButton?.props('active')).toBe(false)
       expect(decButton?.props('active')).toBe(true)
     })
   })

--- a/src/components/__tests__/CalculatorKeyboard.test.ts
+++ b/src/components/__tests__/CalculatorKeyboard.test.ts
@@ -1,0 +1,268 @@
+import { describe, it, expect } from 'vitest'
+import { mount } from '@vue/test-utils'
+import CalculatorKeyboard from '../CalculatorKeyboard.vue'
+import CalculatorButton from '../CalculatorButton.vue'
+
+describe('CalculatorKeyboard', () => {
+  describe('Display Mode Active States', () => {
+    it('should activate BIN button when display mode is binary', () => {
+      const wrapper = mount(CalculatorKeyboard, {
+        props: {
+          displayMode: 'binary',
+        },
+      })
+
+      const buttons = wrapper.findAllComponents(CalculatorButton)
+      const binButton = buttons.find(button => button.props('value') === 'bin')
+      const decButton = buttons.find(button => button.props('value') === 'dec')
+
+      expect(binButton?.props('active')).toBe(true)
+      expect(decButton?.props('active')).toBe(false)
+    })
+
+    it('should activate DEC button when display mode is decimal', () => {
+      const wrapper = mount(CalculatorKeyboard, {
+        props: {
+          displayMode: 'decimal',
+        },
+      })
+
+      const buttons = wrapper.findAllComponents(CalculatorButton)
+      const binButton = buttons.find(button => button.props('value') === 'bin')
+      const decButton = buttons.find(button => button.props('value') === 'dec')
+
+      expect(binButton?.props('active')).toBe(false)
+      expect(decButton?.props('active')).toBe(true)
+    })
+
+    it('should default to decimal mode when displayMode prop is not provided', () => {
+      const wrapper = mount(CalculatorKeyboard)
+
+      const buttons = wrapper.findAllComponents(CalculatorButton)
+      const binButton = buttons.find(button => button.props('value') === 'bin')
+      const decButton = buttons.find(button => button.props('value') === 'dec')
+
+      expect(binButton?.props('active')).toBe(false)
+      expect(decButton?.props('active')).toBe(true)
+    })
+
+    it('should not activate OCT or HEX buttons regardless of display mode', () => {
+      const wrapper = mount(CalculatorKeyboard, {
+        props: {
+          displayMode: 'binary',
+        },
+      })
+
+      const buttons = wrapper.findAllComponents(CalculatorButton)
+      const octButton = buttons.find(button => button.props('value') === 'oct')
+      const hexButton = buttons.find(button => button.props('value') === 'hex')
+
+      expect(octButton?.props('active')).toBe(false)
+      expect(hexButton?.props('active')).toBe(false)
+    })
+  })
+
+  describe('Display Mode Switching', () => {
+    it('should update active states when display mode changes from decimal to binary', async () => {
+      const wrapper = mount(CalculatorKeyboard, {
+        props: {
+          displayMode: 'decimal',
+        },
+      })
+
+      // Initially DEC should be active
+      let buttons = wrapper.findAllComponents(CalculatorButton)
+      let binButton = buttons.find(button => button.props('value') === 'bin')
+      let decButton = buttons.find(button => button.props('value') === 'dec')
+      
+      expect(binButton?.props('active')).toBe(false)
+      expect(decButton?.props('active')).toBe(true)
+
+      // Change to binary mode
+      await wrapper.setProps({ displayMode: 'binary' })
+
+      // Now BIN should be active
+      buttons = wrapper.findAllComponents(CalculatorButton)
+      binButton = buttons.find(button => button.props('value') === 'bin')
+      decButton = buttons.find(button => button.props('value') === 'dec')
+
+      expect(binButton?.props('active')).toBe(true)
+      expect(decButton?.props('active')).toBe(false)
+    })
+
+    it('should update active states when display mode changes from binary to decimal', async () => {
+      const wrapper = mount(CalculatorKeyboard, {
+        props: {
+          displayMode: 'binary',
+        },
+      })
+
+      // Initially BIN should be active
+      let buttons = wrapper.findAllComponents(CalculatorButton)
+      let binButton = buttons.find(button => button.props('value') === 'bin')
+      let decButton = buttons.find(button => button.props('value') === 'dec')
+      
+      expect(binButton?.props('active')).toBe(true)
+      expect(decButton?.props('active')).toBe(false)
+
+      // Change to decimal mode
+      await wrapper.setProps({ displayMode: 'decimal' })
+
+      // Now DEC should be active
+      buttons = wrapper.findAllComponents(CalculatorButton)
+      binButton = buttons.find(button => button.props('value') === 'bin')
+      decButton = buttons.find(button => button.props('value') === 'dec')
+
+      expect(binButton?.props('active')).toBe(false)
+      expect(decButton?.props('active')).toBe(true)
+    })
+  })
+
+  describe('Button Event Handling', () => {
+    it('should emit buttonPress event when BIN button is clicked', async () => {
+      const wrapper = mount(CalculatorKeyboard, {
+        props: {
+          displayMode: 'decimal',
+        },
+      })
+
+      const buttons = wrapper.findAllComponents(CalculatorButton)
+      const binButton = buttons.find(button => button.props('value') === 'bin')
+
+      await binButton?.trigger('click')
+
+      expect(wrapper.emitted('buttonPress')).toBeTruthy()
+      expect(wrapper.emitted('buttonPress')![0]).toEqual(['bin'])
+    })
+
+    it('should emit buttonPress event when DEC button is clicked', async () => {
+      const wrapper = mount(CalculatorKeyboard, {
+        props: {
+          displayMode: 'binary',
+        },
+      })
+
+      const buttons = wrapper.findAllComponents(CalculatorButton)
+      const decButton = buttons.find(button => button.props('value') === 'dec')
+
+      await decButton?.trigger('click')
+
+      expect(wrapper.emitted('buttonPress')).toBeTruthy()
+      expect(wrapper.emitted('buttonPress')![0]).toEqual(['dec'])
+    })
+
+    it('should emit buttonPress event for all keyboard buttons', async () => {
+      const wrapper = mount(CalculatorKeyboard)
+
+      const buttons = wrapper.findAllComponents(CalculatorButton)
+      
+      // Test a few different button types
+      const testButtons = [
+        { value: 'bin', label: 'BIN' },
+        { value: 'enter', label: 'Enter' },
+        { value: '7', label: '7' },
+        { value: '+', label: '+' },
+      ]
+
+      for (const testButton of testButtons) {
+        const button = buttons.find(b => b.props('value') === testButton.value)
+        if (button) {
+          await button.trigger('click')
+          expect(wrapper.emitted('buttonPress')).toBeTruthy()
+        }
+      }
+    })
+  })
+
+  describe('Keyboard Layout', () => {
+    it('should render all expected display mode buttons', () => {
+      const wrapper = mount(CalculatorKeyboard)
+
+      const buttons = wrapper.findAllComponents(CalculatorButton)
+      const displayModeButtons = ['bin', 'oct', 'dec', 'hex']
+
+      for (const buttonValue of displayModeButtons) {
+        const button = buttons.find(b => b.props('value') === buttonValue)
+        expect(button).toBeTruthy()
+      }
+    })
+
+    it('should render all numeric buttons', () => {
+      const wrapper = mount(CalculatorKeyboard)
+
+      const buttons = wrapper.findAllComponents(CalculatorButton)
+      const numericButtons = ['0', '1', '2', '3', '4', '5', '6', '7', '8', '9']
+
+      for (const buttonValue of numericButtons) {
+        const button = buttons.find(b => b.props('value') === buttonValue)
+        expect(button).toBeTruthy()
+      }
+    })
+
+    it('should render all operator buttons', () => {
+      const wrapper = mount(CalculatorKeyboard)
+
+      const buttons = wrapper.findAllComponents(CalculatorButton)
+      const operatorButtons = ['+', '-', '×', '÷']
+
+      for (const buttonValue of operatorButtons) {
+        const button = buttons.find(b => b.props('value') === buttonValue)
+        expect(button).toBeTruthy()
+      }
+    })
+
+    it('should render all function buttons', () => {
+      const wrapper = mount(CalculatorKeyboard)
+
+      const buttons = wrapper.findAllComponents(CalculatorButton)
+      const functionButtons = ['enter', 'toggle-sign', 'eex', 'delete', 'undo', 'swap', 'drop']
+
+      for (const buttonValue of functionButtons) {
+        const button = buttons.find(b => b.props('value') === buttonValue)
+        expect(button).toBeTruthy()
+      }
+    })
+  })
+
+  describe('Visual States', () => {
+    it('should apply active visual state to BIN button in binary mode', () => {
+      const wrapper = mount(CalculatorKeyboard, {
+        props: {
+          displayMode: 'binary',
+        },
+      })
+
+      const buttons = wrapper.findAllComponents(CalculatorButton)
+      const binButton = buttons.find(button => button.props('value') === 'bin')
+
+      expect(binButton?.props('active')).toBe(true)
+      expect(binButton?.classes()).toContain('button-active')
+    })
+
+    it('should apply active visual state to DEC button in decimal mode', () => {
+      const wrapper = mount(CalculatorKeyboard, {
+        props: {
+          displayMode: 'decimal',
+        },
+      })
+
+      const buttons = wrapper.findAllComponents(CalculatorButton)
+      const decButton = buttons.find(button => button.props('value') === 'dec')
+
+      expect(decButton?.props('active')).toBe(true)
+      expect(decButton?.classes()).toContain('button-active')
+    })
+
+    it('should maintain correct button types for display mode buttons', () => {
+      const wrapper = mount(CalculatorKeyboard)
+
+      const buttons = wrapper.findAllComponents(CalculatorButton)
+      const displayModeButtons = ['bin', 'oct', 'dec', 'hex']
+
+      for (const buttonValue of displayModeButtons) {
+        const button = buttons.find(b => b.props('value') === buttonValue)
+        expect(button?.props('type')).toBe('function')
+      }
+    })
+  })
+})

--- a/src/stores/__tests__/rpnCalculator.display.test.ts
+++ b/src/stores/__tests__/rpnCalculator.display.test.ts
@@ -20,20 +20,64 @@ describe('RPN Calculator Store - Display Mode Tests', () => {
       expect(store.displayMode).toBe('binary')
     })
 
+    it('should switch to octal display mode', () => {
+      store.setDisplayMode('octal')
+      expect(store.displayMode).toBe('octal')
+    })
+
     it('should switch to decimal display mode', () => {
       store.setDisplayMode('binary')
       store.setDisplayMode('decimal')
       expect(store.displayMode).toBe('decimal')
     })
 
-    it('should toggle between decimal and binary modes', () => {
+    it('should toggle between decimal, binary, and octal modes', () => {
       expect(store.displayMode).toBe('decimal')
 
       store.toggleDisplayMode()
       expect(store.displayMode).toBe('binary')
 
       store.toggleDisplayMode()
+      expect(store.displayMode).toBe('octal')
+
+      store.toggleDisplayMode()
       expect(store.displayMode).toBe('decimal')
+    })
+  })
+
+  describe('Octal String Conversion', () => {
+    it('should convert zero to octal', () => {
+      expect(store.toOctalString(0)).toBe('0o0')
+    })
+
+    it('should convert positive integers to octal', () => {
+      expect(store.toOctalString(1)).toBe('0o1')
+      expect(store.toOctalString(8)).toBe('0o10')
+      expect(store.toOctalString(15)).toBe('0o17')
+      expect(store.toOctalString(64)).toBe('0o100')
+      expect(store.toOctalString(255)).toBe('0o377')
+    })
+
+    it("should convert negative integers to octal (two's complement)", () => {
+      expect(store.toOctalString(-1)).toBe('0o37777777777')
+      expect(store.toOctalString(-8)).toBe('0o37777777770')
+    })
+
+    it('should convert decimal numbers to octal (integer part only)', () => {
+      expect(store.toOctalString(8.7)).toBe('0o10')
+      expect(store.toOctalString(15.9)).toBe('0o17')
+      expect(store.toOctalString(-7.14)).toBe('0o37777777771')
+    })
+
+    it('should handle special values', () => {
+      expect(store.toOctalString(Infinity)).toBe('Error')
+      expect(store.toOctalString(-Infinity)).toBe('Error')
+      expect(store.toOctalString(NaN)).toBe('Error')
+    })
+
+    it('should handle large numbers', () => {
+      expect(store.toOctalString(512)).toBe('0o1000')
+      expect(store.toOctalString(4095)).toBe('0o7777')
     })
   })
 

--- a/src/stores/__tests__/rpnCalculator.display.test.ts
+++ b/src/stores/__tests__/rpnCalculator.display.test.ts
@@ -1,0 +1,327 @@
+import { describe, it, expect, beforeEach } from 'vitest'
+import { setActivePinia, createPinia } from 'pinia'
+import { useRPNStore } from '../rpnCalculator'
+
+describe('RPN Calculator Store - Display Mode Tests', () => {
+  let store: ReturnType<typeof useRPNStore>
+
+  beforeEach(() => {
+    setActivePinia(createPinia())
+    store = useRPNStore()
+  })
+
+  describe('Display Mode Management', () => {
+    it('should initialize with decimal display mode', () => {
+      expect(store.displayMode).toBe('decimal')
+    })
+
+    it('should switch to binary display mode', () => {
+      store.setDisplayMode('binary')
+      expect(store.displayMode).toBe('binary')
+    })
+
+    it('should switch to decimal display mode', () => {
+      store.setDisplayMode('binary')
+      store.setDisplayMode('decimal')
+      expect(store.displayMode).toBe('decimal')
+    })
+
+    it('should toggle between decimal and binary modes', () => {
+      expect(store.displayMode).toBe('decimal')
+      
+      store.toggleDisplayMode()
+      expect(store.displayMode).toBe('binary')
+      
+      store.toggleDisplayMode()
+      expect(store.displayMode).toBe('decimal')
+    })
+  })
+
+  describe('Binary String Conversion', () => {
+    it('should convert zero to binary', () => {
+      expect(store.toBinaryString(0)).toBe('0b0')
+    })
+
+    it('should convert positive integers to binary', () => {
+      expect(store.toBinaryString(1)).toBe('0b1')
+      expect(store.toBinaryString(5)).toBe('0b101')
+      expect(store.toBinaryString(10)).toBe('0b1010')
+      expect(store.toBinaryString(255)).toBe('0b11111111')
+    })
+
+    it('should convert negative integers to binary (two\'s complement)', () => {
+      expect(store.toBinaryString(-1)).toBe('0b11111111111111111111111111111111')
+      expect(store.toBinaryString(-5)).toBe('0b11111111111111111111111111111011')
+    })
+
+    it('should convert decimal numbers to binary (integer part only)', () => {
+      expect(store.toBinaryString(5.7)).toBe('0b101')
+      expect(store.toBinaryString(10.9)).toBe('0b1010')
+      expect(store.toBinaryString(-3.14)).toBe('0b11111111111111111111111111111101')
+    })
+
+    it('should handle special values', () => {
+      expect(store.toBinaryString(Infinity)).toBe('Error')
+      expect(store.toBinaryString(-Infinity)).toBe('Error')
+      expect(store.toBinaryString(NaN)).toBe('Error')
+    })
+
+    it('should handle large numbers', () => {
+      expect(store.toBinaryString(1024)).toBe('0b10000000000')
+      expect(store.toBinaryString(65535)).toBe('0b1111111111111111')
+    })
+  })
+
+  describe('Stack Display in Binary Mode', () => {
+    beforeEach(() => {
+      store.clearAll()
+    })
+
+    it('should display stack values in binary when in binary mode', () => {
+      // Add some values to stack
+      store.inputDigit('5')
+      store.enterNumber()
+      store.inputDigit('10')
+      store.enterNumber()
+      store.inputDigit('15')
+      store.enterNumber()
+
+      // Switch to binary mode
+      store.setDisplayMode('binary')
+
+      // Check displayStack computed property
+      const displayStack = store.displayStack
+      expect(displayStack).toEqual([5, 10, 15])
+    })
+
+    it('should handle current input in binary mode', () => {
+      // Start input
+      store.inputDigit('7')
+      store.setDisplayMode('binary')
+
+      // displayStack should include current input
+      const displayStack = store.displayStack
+      expect(displayStack).toEqual([7])
+    })
+
+    it('should handle empty stack in binary mode', () => {
+      store.setDisplayMode('binary')
+      const displayStack = store.displayStack
+      expect(displayStack).toEqual([])
+    })
+
+    it('should preserve stack values when switching display modes', () => {
+      // Add values in decimal mode
+      store.inputDigit('5')
+      store.enterNumber()
+      store.inputDigit('10')
+      store.enterNumber()
+
+      const originalStack = [...store.stack]
+
+      // Switch to binary mode
+      store.setDisplayMode('binary')
+      expect(store.stack).toEqual(originalStack)
+
+      // Switch back to decimal mode
+      store.setDisplayMode('decimal')
+      expect(store.stack).toEqual(originalStack)
+    })
+  })
+
+  describe('Operations in Binary Mode', () => {
+    beforeEach(() => {
+      store.clearAll()
+    })
+
+    it('should perform calculations correctly in binary mode', () => {
+      // Switch to binary mode first
+      store.setDisplayMode('binary')
+
+      // Perform calculation: 5 + 3 = 8
+      store.inputDigit('5')
+      store.enterNumber()
+      store.inputDigit('3')
+      store.performOperation('+')
+
+      expect(store.stack).toEqual([8])
+      expect(store.displayMode).toBe('binary')
+    })
+
+    it('should handle stack operations in binary mode', () => {
+      store.setDisplayMode('binary')
+
+      // Add some values
+      store.inputDigit('5')
+      store.enterNumber()
+      store.inputDigit('10')
+      store.enterNumber()
+      store.inputDigit('15')
+      store.enterNumber()
+
+      expect(store.stack).toEqual([5, 10, 15])
+
+      // Test swap operation
+      store.swapStack()
+      expect(store.stack).toEqual([5, 15, 10])
+
+      // Test drop operation
+      store.dropStack()
+      expect(store.stack).toEqual([5, 15])
+    })
+
+    it('should handle input operations in binary mode', () => {
+      store.setDisplayMode('binary')
+
+      // Test decimal input
+      store.inputDigit('3')
+      store.inputDecimal()
+      store.inputDigit('14')
+      store.enterNumber()
+
+      expect(store.stack).toEqual([3.14])
+
+      // Test sign toggle
+      store.inputDigit('5')
+      store.toggleSign()
+      store.enterNumber()
+
+      expect(store.stack).toEqual([3.14, -5])
+    })
+  })
+
+  describe('Integration Tests', () => {
+    beforeEach(() => {
+      store.clearAll()
+    })
+
+    it('should maintain calculation accuracy regardless of display mode', () => {
+      // Perform calculation in decimal mode
+      store.inputDigit('15')
+      store.enterNumber()
+      store.inputDigit('7')
+      store.performOperation('÷')
+      
+      const decimalResult = store.stack[0]
+
+      // Switch to binary mode
+      store.setDisplayMode('binary')
+      
+      // Result should be the same
+      expect(store.stack[0]).toBe(decimalResult)
+
+      // Switch back to decimal
+      store.setDisplayMode('decimal')
+      expect(store.stack[0]).toBe(decimalResult)
+    })
+
+    it('should handle complex calculations with mode switching', () => {
+      // Start calculation: 10 + 5 = 15
+      store.inputDigit('10')
+      store.enterNumber()
+      store.inputDigit('5')
+      store.performOperation('+')
+      expect(store.stack).toEqual([15])
+
+      // Switch to binary mode
+      store.setDisplayMode('binary')
+
+      // Continue calculation: 15 * 2 = 30
+      store.inputDigit('2')
+      store.performOperation('×')
+      expect(store.stack).toEqual([30])
+
+      // Switch back to decimal
+      store.setDisplayMode('decimal')
+
+      // Final calculation: 30 - 10 = 20
+      store.inputDigit('10')
+      store.performOperation('-')
+      expect(store.stack).toEqual([20])
+    })
+
+    it('should handle undo operations across display mode changes', () => {
+      // Perform operation in decimal mode
+      store.inputDigit('8')
+      store.enterNumber()
+      store.inputDigit('4')
+      store.performOperation('÷')
+      expect(store.stack).toEqual([2])
+
+      // Switch to binary mode
+      store.setDisplayMode('binary')
+
+      // Undo operation
+      store.undoLastOperation()
+      expect(store.stack).toEqual([8, 4])
+
+      // Switch back to decimal
+      store.setDisplayMode('decimal')
+      expect(store.stack).toEqual([8, 4])
+    })
+
+    it('should handle EEX (scientific notation) input in binary mode', () => {
+      store.setDisplayMode('binary')
+
+      // Input 1.5e2 (150)
+      store.inputDigit('1')
+      store.inputDecimal()
+      store.inputDigit('5')
+      store.inputEEX()
+      store.inputDigit('2')
+      store.enterNumber()
+
+      expect(store.stack).toEqual([150])
+      expect(store.displayMode).toBe('binary')
+    })
+
+    it('should preserve display mode through clear operations', () => {
+      store.setDisplayMode('binary')
+      
+      // Add some values
+      store.inputDigit('5')
+      store.enterNumber()
+      store.inputDigit('10')
+      store.enterNumber()
+
+      // Clear all
+      store.clearAll()
+
+      // Display mode should be preserved
+      expect(store.displayMode).toBe('binary')
+      expect(store.stack).toEqual([])
+    })
+  })
+
+  describe('Edge Cases', () => {
+    it('should handle very large numbers in binary mode', () => {
+      const largeNumber = 2147483647 // 2^31 - 1
+      expect(store.toBinaryString(largeNumber)).toBe('0b1111111111111111111111111111111')
+    })
+
+    it('should handle zero division in binary mode', () => {
+      store.setDisplayMode('binary')
+      
+      store.inputDigit('5')
+      store.enterNumber()
+      store.inputDigit('0')
+      store.performOperation('÷')
+      
+      expect(store.stack).toEqual([0])
+    })
+
+    it('should handle repeated Enter operations in binary mode', () => {
+      store.setDisplayMode('binary')
+      
+      store.inputDigit('7')
+      store.enterNumber()
+      
+      // Multiple Enter operations
+      store.enterNumber()
+      store.enterNumber()
+      store.enterNumber()
+      
+      expect(store.stack).toEqual([7, 7, 7, 7])
+    })
+  })
+})

--- a/src/stores/__tests__/rpnCalculator.display.test.ts
+++ b/src/stores/__tests__/rpnCalculator.display.test.ts
@@ -25,13 +25,18 @@ describe('RPN Calculator Store - Display Mode Tests', () => {
       expect(store.displayMode).toBe('octal')
     })
 
+    it('should switch to hexadecimal display mode', () => {
+      store.setDisplayMode('hexadecimal')
+      expect(store.displayMode).toBe('hexadecimal')
+    })
+
     it('should switch to decimal display mode', () => {
       store.setDisplayMode('binary')
       store.setDisplayMode('decimal')
       expect(store.displayMode).toBe('decimal')
     })
 
-    it('should toggle between decimal, binary, and octal modes', () => {
+    it('should toggle between decimal, binary, octal, and hexadecimal modes', () => {
       expect(store.displayMode).toBe('decimal')
 
       store.toggleDisplayMode()
@@ -41,7 +46,53 @@ describe('RPN Calculator Store - Display Mode Tests', () => {
       expect(store.displayMode).toBe('octal')
 
       store.toggleDisplayMode()
+      expect(store.displayMode).toBe('hexadecimal')
+
+      store.toggleDisplayMode()
       expect(store.displayMode).toBe('decimal')
+    })
+  })
+
+  describe('Hexadecimal String Conversion', () => {
+    it('should convert zero to hexadecimal', () => {
+      expect(store.toHexString(0)).toBe('0x0')
+    })
+
+    it('should convert positive integers to hexadecimal', () => {
+      expect(store.toHexString(1)).toBe('0x1')
+      expect(store.toHexString(10)).toBe('0xA')
+      expect(store.toHexString(15)).toBe('0xF')
+      expect(store.toHexString(16)).toBe('0x10')
+      expect(store.toHexString(255)).toBe('0xFF')
+      expect(store.toHexString(4095)).toBe('0xFFF')
+    })
+
+    it("should convert negative integers to hexadecimal (two's complement)", () => {
+      expect(store.toHexString(-1)).toBe('0xFFFFFFFF')
+      expect(store.toHexString(-16)).toBe('0xFFFFFFF0')
+    })
+
+    it('should convert decimal numbers to hexadecimal (integer part only)', () => {
+      expect(store.toHexString(15.7)).toBe('0xF')
+      expect(store.toHexString(255.9)).toBe('0xFF')
+      expect(store.toHexString(-15.14)).toBe('0xFFFFFFF1')
+    })
+
+    it('should handle special values', () => {
+      expect(store.toHexString(Infinity)).toBe('Error')
+      expect(store.toHexString(-Infinity)).toBe('Error')
+      expect(store.toHexString(NaN)).toBe('Error')
+    })
+
+    it('should handle large numbers', () => {
+      expect(store.toHexString(4096)).toBe('0x1000')
+      expect(store.toHexString(65535)).toBe('0xFFFF')
+    })
+
+    it('should use uppercase letters for hex digits', () => {
+      expect(store.toHexString(170)).toBe('0xAA')
+      expect(store.toHexString(187)).toBe('0xBB')
+      expect(store.toHexString(204)).toBe('0xCC')
     })
   })
 

--- a/src/stores/__tests__/rpnCalculator.display.test.ts
+++ b/src/stores/__tests__/rpnCalculator.display.test.ts
@@ -28,10 +28,10 @@ describe('RPN Calculator Store - Display Mode Tests', () => {
 
     it('should toggle between decimal and binary modes', () => {
       expect(store.displayMode).toBe('decimal')
-      
+
       store.toggleDisplayMode()
       expect(store.displayMode).toBe('binary')
-      
+
       store.toggleDisplayMode()
       expect(store.displayMode).toBe('decimal')
     })
@@ -49,7 +49,7 @@ describe('RPN Calculator Store - Display Mode Tests', () => {
       expect(store.toBinaryString(255)).toBe('0b11111111')
     })
 
-    it('should convert negative integers to binary (two\'s complement)', () => {
+    it("should convert negative integers to binary (two's complement)", () => {
       expect(store.toBinaryString(-1)).toBe('0b11111111111111111111111111111111')
       expect(store.toBinaryString(-5)).toBe('0b11111111111111111111111111111011')
     })
@@ -201,12 +201,12 @@ describe('RPN Calculator Store - Display Mode Tests', () => {
       store.enterNumber()
       store.inputDigit('7')
       store.performOperation('÷')
-      
+
       const decimalResult = store.stack[0]
 
       // Switch to binary mode
       store.setDisplayMode('binary')
-      
+
       // Result should be the same
       expect(store.stack[0]).toBe(decimalResult)
 
@@ -277,7 +277,7 @@ describe('RPN Calculator Store - Display Mode Tests', () => {
 
     it('should preserve display mode through clear operations', () => {
       store.setDisplayMode('binary')
-      
+
       // Add some values
       store.inputDigit('5')
       store.enterNumber()
@@ -301,26 +301,26 @@ describe('RPN Calculator Store - Display Mode Tests', () => {
 
     it('should handle zero division in binary mode', () => {
       store.setDisplayMode('binary')
-      
+
       store.inputDigit('5')
       store.enterNumber()
       store.inputDigit('0')
       store.performOperation('÷')
-      
+
       expect(store.stack).toEqual([0])
     })
 
     it('should handle repeated Enter operations in binary mode', () => {
       store.setDisplayMode('binary')
-      
+
       store.inputDigit('7')
       store.enterNumber()
-      
+
       // Multiple Enter operations
       store.enterNumber()
       store.enterNumber()
       store.enterNumber()
-      
+
       expect(store.stack).toEqual([7, 7, 7, 7])
     })
   })

--- a/src/stores/rpnCalculator.ts
+++ b/src/stores/rpnCalculator.ts
@@ -12,7 +12,7 @@ export const useRPNStore = defineStore('rpnCalculator', () => {
   const eexMode = ref<boolean>(false)
   const exponent = ref<string>('')
   const eexJustEntered = ref<boolean>(false)
-  const displayMode = ref<'decimal' | 'binary' | 'octal'>('decimal')
+  const displayMode = ref<'decimal' | 'binary' | 'octal' | 'hexadecimal'>('decimal')
 
   // Helper function for HP-style stack lift
   const liftStack = () => {
@@ -80,6 +80,27 @@ export const useRPNStore = defineStore('rpnCalculator', () => {
     // Positive numbers
     const octalStr = integerPart.toString(8)
     return '0o' + octalStr
+  }
+
+  // Helper function to convert number to hexadecimal string
+  const toHexString = (value: number): string => {
+    // Handle special cases
+    if (value === 0) return '0x0'
+    if (!isFinite(value)) return 'Error'
+
+    // For decimal numbers, only convert the integer part
+    const integerPart = Math.trunc(value)
+
+    // Handle negative numbers using two's complement (32-bit)
+    if (integerPart < 0) {
+      // Convert to 32-bit two's complement then to hexadecimal
+      const twosComplement = (integerPart >>> 0).toString(16).toUpperCase()
+      return '0x' + twosComplement
+    }
+
+    // Positive numbers
+    const hexStr = integerPart.toString(16).toUpperCase()
+    return '0x' + hexStr
   }
 
   // Computed
@@ -332,7 +353,7 @@ export const useRPNStore = defineStore('rpnCalculator', () => {
     eexJustEntered.value = false
   }
 
-  const setDisplayMode = (mode: 'decimal' | 'binary' | 'octal') => {
+  const setDisplayMode = (mode: 'decimal' | 'binary' | 'octal' | 'hexadecimal') => {
     displayMode.value = mode
   }
 
@@ -341,6 +362,8 @@ export const useRPNStore = defineStore('rpnCalculator', () => {
       displayMode.value = 'binary'
     } else if (displayMode.value === 'binary') {
       displayMode.value = 'octal'
+    } else if (displayMode.value === 'octal') {
+      displayMode.value = 'hexadecimal'
     } else {
       displayMode.value = 'decimal'
     }
@@ -365,6 +388,7 @@ export const useRPNStore = defineStore('rpnCalculator', () => {
     // Helpers
     toBinaryString,
     toOctalString,
+    toHexString,
 
     // Actions
     inputDigit,

--- a/src/stores/rpnCalculator.ts
+++ b/src/stores/rpnCalculator.ts
@@ -12,6 +12,7 @@ export const useRPNStore = defineStore('rpnCalculator', () => {
   const eexMode = ref<boolean>(false)
   const exponent = ref<string>('')
   const eexJustEntered = ref<boolean>(false)
+  const displayMode = ref<'decimal' | 'binary'>('decimal')
 
   // Helper function for HP-style stack lift
   const liftStack = () => {
@@ -37,6 +38,27 @@ export const useRPNStore = defineStore('rpnCalculator', () => {
     }
 
     return mantissa * Math.pow(10, exp)
+  }
+
+  // Helper function to convert number to binary string
+  const toBinaryString = (value: number): string => {
+    // Handle special cases
+    if (value === 0) return '0b0'
+    if (!isFinite(value)) return 'Error'
+    
+    // For decimal numbers, only convert the integer part
+    const integerPart = Math.trunc(value)
+    
+    // Handle negative numbers using two's complement (32-bit)
+    if (integerPart < 0) {
+      // Convert to 32-bit two's complement
+      const twosComplement = (integerPart >>> 0).toString(2)
+      return '0b' + twosComplement
+    }
+    
+    // Positive numbers
+    const binaryStr = integerPart.toString(2)
+    return '0b' + binaryStr
   }
 
   // Computed
@@ -289,6 +311,14 @@ export const useRPNStore = defineStore('rpnCalculator', () => {
     eexJustEntered.value = false
   }
 
+  const setDisplayMode = (mode: 'decimal' | 'binary') => {
+    displayMode.value = mode
+  }
+
+  const toggleDisplayMode = () => {
+    displayMode.value = displayMode.value === 'decimal' ? 'binary' : 'decimal'
+  }
+
   return {
     // State
     stack,
@@ -299,10 +329,14 @@ export const useRPNStore = defineStore('rpnCalculator', () => {
     eexMode,
     exponent,
     eexJustEntered,
+    displayMode,
 
     // Computed
     displayStack,
     currentDisplay,
+
+    // Helpers
+    toBinaryString,
 
     // Actions
     inputDigit,
@@ -316,5 +350,7 @@ export const useRPNStore = defineStore('rpnCalculator', () => {
     deleteLastDigit,
     undoLastOperation,
     clearAll,
+    setDisplayMode,
+    toggleDisplayMode,
   }
 })

--- a/src/stores/rpnCalculator.ts
+++ b/src/stores/rpnCalculator.ts
@@ -12,7 +12,7 @@ export const useRPNStore = defineStore('rpnCalculator', () => {
   const eexMode = ref<boolean>(false)
   const exponent = ref<string>('')
   const eexJustEntered = ref<boolean>(false)
-  const displayMode = ref<'decimal' | 'binary'>('decimal')
+  const displayMode = ref<'decimal' | 'binary' | 'octal'>('decimal')
 
   // Helper function for HP-style stack lift
   const liftStack = () => {
@@ -59,6 +59,27 @@ export const useRPNStore = defineStore('rpnCalculator', () => {
     // Positive numbers
     const binaryStr = integerPart.toString(2)
     return '0b' + binaryStr
+  }
+
+  // Helper function to convert number to octal string
+  const toOctalString = (value: number): string => {
+    // Handle special cases
+    if (value === 0) return '0o0'
+    if (!isFinite(value)) return 'Error'
+
+    // For decimal numbers, only convert the integer part
+    const integerPart = Math.trunc(value)
+
+    // Handle negative numbers using two's complement (32-bit)
+    if (integerPart < 0) {
+      // Convert to 32-bit two's complement then to octal
+      const twosComplement = (integerPart >>> 0).toString(8)
+      return '0o' + twosComplement
+    }
+
+    // Positive numbers
+    const octalStr = integerPart.toString(8)
+    return '0o' + octalStr
   }
 
   // Computed
@@ -311,12 +332,18 @@ export const useRPNStore = defineStore('rpnCalculator', () => {
     eexJustEntered.value = false
   }
 
-  const setDisplayMode = (mode: 'decimal' | 'binary') => {
+  const setDisplayMode = (mode: 'decimal' | 'binary' | 'octal') => {
     displayMode.value = mode
   }
 
   const toggleDisplayMode = () => {
-    displayMode.value = displayMode.value === 'decimal' ? 'binary' : 'decimal'
+    if (displayMode.value === 'decimal') {
+      displayMode.value = 'binary'
+    } else if (displayMode.value === 'binary') {
+      displayMode.value = 'octal'
+    } else {
+      displayMode.value = 'decimal'
+    }
   }
 
   return {
@@ -337,6 +364,7 @@ export const useRPNStore = defineStore('rpnCalculator', () => {
 
     // Helpers
     toBinaryString,
+    toOctalString,
 
     // Actions
     inputDigit,

--- a/src/stores/rpnCalculator.ts
+++ b/src/stores/rpnCalculator.ts
@@ -45,17 +45,17 @@ export const useRPNStore = defineStore('rpnCalculator', () => {
     // Handle special cases
     if (value === 0) return '0b0'
     if (!isFinite(value)) return 'Error'
-    
+
     // For decimal numbers, only convert the integer part
     const integerPart = Math.trunc(value)
-    
+
     // Handle negative numbers using two's complement (32-bit)
     if (integerPart < 0) {
       // Convert to 32-bit two's complement
       const twosComplement = (integerPart >>> 0).toString(2)
       return '0b' + twosComplement
     }
-    
+
     // Positive numbers
     const binaryStr = integerPart.toString(2)
     return '0b' + binaryStr


### PR DESCRIPTION
## Summary
- BIN/OCT/DEC/HEXキーによる数値表示形式切り替え機能を実装
- 数値の二進数(0b)、八進数(0o)、十六進数(0x)表示対応
- アクティブボタンの視覚的フィードバック追加
- 包括的なE2Eテスト（12テストケース）を追加

## 主な変更内容
- CalculatorKeyboard.vue: BIN/OCT/DEC/HEXボタンとアクティブ状態の実装
- CalculatorDisplay.vue: 各進数での数値表示フォーマット対応
- rpnCalculator.ts: 表示モード切り替えロジックと進数変換関数の実装
- 新規E2Eテスト: e2e/number-base-display.spec.ts（12テストケース）

## Test plan
- [x] BIN/OCT/DEC/HEXキーの基本動作テスト
- [x] 各表示モードでの数値表示形式テスト
- [x] アクティブボタン状態テスト
- [x] 表示モード切り替え後の計算機能テスト
- [x] 負の数値・ゼロ・小数の表示テスト
- [x] 全36テスト（Chrome/Firefox/Safari）が成功

🤖 Generated with [Claude Code](https://claude.ai/code)